### PR TITLE
Remove "ld: warning: PIE disabled." on OSX

### DIFF
--- a/config.go
+++ b/config.go
@@ -9,7 +9,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"plugin"
 	"reflect"
 	"strconv"
 	"strings"
@@ -123,38 +122,7 @@ func (c *ProviderConfig) Load(builtins ...Provider) (Provider, error) {
 		}
 	}
 
-	// Attempt to load a plugin provider
-	p, err := plugin.Open(resolvePath(c.Provider))
-	if err != nil {
-		return nil, errors.New("The provider plugin '" + c.Provider + "' could not be opened. " + err.Error())
-	}
-
-	// Get the symbol
-	sym, err := p.Lookup("New")
-	if err != nil {
-		return nil, errors.New("The provider '" + c.Provider + "' does not contain 'func New() interface{}' symbol")
-	}
-
-	// Resolve the
-	pFactory, validFunc := sym.(*func() interface{})
-	if !validFunc {
-		return nil, errors.New("The provider '" + c.Provider + "' does not contain 'func New() interface{}' symbol")
-	}
-
-	// Construct the provider
-	provider, validProv := ((*pFactory)()).(Provider)
-	if !validProv {
-		return nil, errors.New("The provider '" + c.Provider + "' does not implement 'Provider'")
-	}
-
-	// Configure the provider
-	err = provider.Configure(c.Config)
-	if err != nil {
-		return nil, errors.New("The provider '" + c.Provider + "' could not be configured")
-	}
-
-	// Succesfully opened and configured a provider
-	return provider, nil
+	return c.LoadPlugin()
 }
 
 // LoadProvider loads a provider from the configuration or panics if the configuration is

--- a/config_plugin.go
+++ b/config_plugin.go
@@ -1,0 +1,43 @@
+// +build !darwin
+
+package config
+
+import (
+	"errors"
+	"plugin"
+)
+
+func (c *ProviderConfig) LoadPlugin() (Provider, error) {
+	// Attempt to load a plugin provider
+	p, err := plugin.Open(resolvePath(c.Provider))
+	if err != nil {
+		return nil, errors.New("The provider plugin '" + c.Provider + "' could not be opened. " + err.Error())
+	}
+
+	// Get the symbol
+	sym, err := p.Lookup("New")
+	if err != nil {
+		return nil, errors.New("The provider '" + c.Provider + "' does not contain 'func New() interface{}' symbol")
+	}
+
+	// Resolve the
+	pFactory, validFunc := sym.(*func() interface{})
+	if !validFunc {
+		return nil, errors.New("The provider '" + c.Provider + "' does not contain 'func New() interface{}' symbol")
+	}
+
+	// Construct the provider
+	provider, validProv := ((*pFactory)()).(Provider)
+	if !validProv {
+		return nil, errors.New("The provider '" + c.Provider + "' does not implement 'Provider'")
+	}
+
+	// Configure the provider
+	err = provider.Configure(c.Config)
+	if err != nil {
+		return nil, errors.New("The provider '" + c.Provider + "' could not be configured")
+	}
+
+	// Succesfully opened and configured a provider
+	return provider, nil
+}

--- a/config_plugin_darwin.go
+++ b/config_plugin_darwin.go
@@ -1,0 +1,7 @@
+package config
+
+import "errors"
+
+func (c *ProviderConfig) LoadPlugin() (Provider, error) {
+	return nil, errors.New("The provider plugin '" + c.Provider + "' could not be opened. Plugin not supported on darwin.")
+}


### PR DESCRIPTION
In OSx (darwin), we get this annoying warning:

```
ld: warning: PIE disabled. Absolute addressing (perhaps -mdynamic-no-pic) not allowed in code signed PIE, but used in type..eqfunc.[106]string from /var/folders/hz/nqhk5_3n4v9_rkgjdmqk5k5w0000gn/T/go-link-728052133/go.o. To fix this warning, don't compile with -mdynamic-no-pic or link with -Wl,-no_pie
```

every time we run a program that import the "plugin" package in go >= 1.9.
If we run `go test ./...`, the warning will be printed many times.

This pull request ensure that when the program is run on OSx, the plugin part is excluded of the build.

As far as I know, plugin are not supported on OSx.
```
$ go version
go version go1.9.4 darwin/amd64
$ go build -buildmode=plugin plugin.go
-buildmode=plugin not supported on darwin/amd64
```